### PR TITLE
adding background color to the header component

### DIFF
--- a/js/header.component.js
+++ b/js/header.component.js
@@ -28,7 +28,7 @@ class HeaderComponent extends HTMLElement {
       }
 
       .header__nav {
-      position: absolute;
+        position: absolute;
         width: 100%;
         max-width: 250px;
         height: 100%;
@@ -37,7 +37,13 @@ class HeaderComponent extends HTMLElement {
         right: 0;
         background-color: #262a36;
         z-index: 3;
-        backdrop-filter: blur(81.5485px);
+      }
+      
+      @supports(backdrop-filter: none) {
+        .backdrop {
+          backdrop-filter: blur(81.5485px);
+          background-color: rgba(255, 255, 255, 0.04);
+        }
       }
 
       .header__nav--hidden {
@@ -109,8 +115,13 @@ class HeaderComponent extends HTMLElement {
           height: 96px;
           max-width: 450px;
           background-color: rgba(255, 255, 255, 0.04);
-          backdrop-filter: blur(81.5485px);
           display: flex;
+        }
+
+        @supports(backdrop-filter: none) {
+          .backdrop {
+            backdrop-filter: none;
+          }
         }
 
         .menu {
@@ -240,7 +251,7 @@ class HeaderComponent extends HTMLElement {
             />
           </a>
           <div class="line"></div>
-          <nav class="header__nav">
+          <nav class="backdrop header__nav">
             <ul class="header__menu menu">
               <li class="menu__item">
                 <a class="menu__link" href="index.html">

--- a/js/header.component.js
+++ b/js/header.component.js
@@ -37,7 +37,10 @@ class HeaderComponent extends HTMLElement {
         right: 0;
         background-color: rgba(255, 255, 255, 0.04);
         backdrop-filter: blur(81.5485px);
+        backdrop-filter: blur(0px);  
+        background-color: #262a36;
         z-index: 3;
+        backdrop-filter: blur(81.5485px);
       }
 
       .header__nav--hidden {

--- a/js/header.component.js
+++ b/js/header.component.js
@@ -28,16 +28,13 @@ class HeaderComponent extends HTMLElement {
       }
 
       .header__nav {
-        position: absolute;
+      position: absolute;
         width: 100%;
         max-width: 250px;
         height: 100%;
         top: var(--top, -100%);
         bottom: 0;
         right: 0;
-        background-color: rgba(255, 255, 255, 0.04);
-        backdrop-filter: blur(81.5485px);
-        backdrop-filter: blur(0px);  
         background-color: #262a36;
         z-index: 3;
         backdrop-filter: blur(81.5485px);
@@ -277,3 +274,5 @@ class HeaderComponent extends HTMLElement {
 }
 
 customElements.define("header-component", HeaderComponent);
+
+        


### PR DESCRIPTION
hy guys inorder to fix the background-color problem with firefox I copy the color code of background-color in the design and I apply it in the project and also I apply the backdrop-filter on it as given in the design.

this backdrop-filter doesn't work on firefox since the hexcode I apply is  close to the design will make the background of the header-component will look the same as the design in firefox.

there is no problem with chrome that backdrop-filler property will work.

if you can Improve it you can improve it guys.